### PR TITLE
Support `SHF_GNU_RETAIN`

### DIFF
--- a/plinky/linktest/gc-sections/foo.S
+++ b/plinky/linktest/gc-sections/foo.S
@@ -23,5 +23,14 @@ name:
 surname:
     .asciz "Albini"
 
+.section .rodata.retained,"aR"
+    .asciz "I want to be retained"
+
+.section .rodata.retained_same_name,"a",%progbits
+    .asciz "I also happen to be retained because I have the same name"
+
+.section .rodata.retained_same_name,"aR",%progbits
+    .asciz "I really want to be retained"
+
 .section .comment,"MS",@progbits,1
     .asciz "Sample comment"

--- a/plinky/linktest/gc-sections/test-64bit.snap
+++ b/plinky/linktest/gc-sections/test-64bit.snap
@@ -8,7 +8,7 @@ no stdout present
 === stderr ===
 debug print: loaded object
  │
- │  class: Elf64, endian: Little, abi: SystemV, machine: X86_64
+ │  class: Elf64, endian: Little, abi: Gnu, machine: X86_64
  │
  │  section .comment#0 (no perms) in foo.o
  │   │
@@ -33,6 +33,32 @@ debug print: loaded object
  │   │  ╭──────────────────────┬─────────╮
  │   │  │ 50 69 65 74 72 6f 00 │ Pietro. │
  │   │  ╰──────────────────────┴─────────╯
+ │   ┴
+ │
+ │  section .rodata.retained (perms: r) in foo.o
+ │   │
+ │   │  ╭─────────────────────────────────────────────────┬──────────────────╮
+ │   │  │ 49 20 77 61 6e 74 20 74 6f 20 62 65 20 72 65 74 │ I want to be ret │
+ │   │  │ 61 69 6e 65 64 00                               │ ained.           │
+ │   │  ╰─────────────────────────────────────────────────┴──────────────────╯
+ │   ┴
+ │
+ │  section .rodata.retained_same_name#0 (perms: r) in foo.o
+ │   │
+ │   │  ╭─────────────────────────────────────────────────┬──────────────────╮
+ │   │  │ 49 20 61 6c 73 6f 20 68 61 70 70 65 6e 20 74 6f │ I also happen to │
+ │   │  │ 20 62 65 20 72 65 74 61 69 6e 65 64 20 62 65 63 │  be retained bec │
+ │   │  │ 61 75 73 65 20 49 20 68 61 76 65 20 74 68 65 20 │ ause I have the  │
+ │   │  │ 73 61 6d 65 20 6e 61 6d 65 00                   │ same name.       │
+ │   │  ╰─────────────────────────────────────────────────┴──────────────────╯
+ │   ┴
+ │
+ │  section .rodata.retained_same_name#1 (perms: r) in foo.o
+ │   │
+ │   │  ╭─────────────────────────────────────────────────┬──────────────────╮
+ │   │  │ 49 20 72 65 61 6c 6c 79 20 77 61 6e 74 20 74 6f │ I really want to │
+ │   │  │ 20 62 65 20 72 65 74 61 69 6e 65 64 00          │  be retained.    │
+ │   │  ╰─────────────────────────────────────────────────┴──────────────────╯
  │   ┴
  │
  │  section .rodata.surname (perms: r) in foo.o
@@ -140,7 +166,7 @@ debug print: garbage collector outcome
 
 debug print: object after relocations are applied
  │
- │  class: Elf64, endian: Little, abi: SystemV, machine: X86_64
+ │  class: Elf64, endian: Little, abi: Gnu, machine: X86_64
  │
  │  section .comment (no perms) in mix of foo.o and <plinky>
  │   │
@@ -174,6 +200,30 @@ debug print: object after relocations are applied
  │   │  ╭──────────────────────┬─────────╮
  │   │  │ 50 69 65 74 72 6f 00 │ Pietro. │
  │   │  ╰──────────────────────┴─────────╯
+ │   ┴
+ │
+ │  section .rodata.retained (perms: r) in foo.o
+ │   │
+ │   │  address: 0x400007
+ │   │
+ │   │  ╭─────────────────────────────────────────────────┬──────────────────╮
+ │   │  │ 49 20 77 61 6e 74 20 74 6f 20 62 65 20 72 65 74 │ I want to be ret │
+ │   │  │ 61 69 6e 65 64 00                               │ ained.           │
+ │   │  ╰─────────────────────────────────────────────────┴──────────────────╯
+ │   ┴
+ │
+ │  section .rodata.retained_same_name (perms: r) in mix of foo.o and foo.o
+ │   │
+ │   │  address: 0x40001d
+ │   │
+ │   │  ╭─────────────────────────────────────────────────┬──────────────────╮
+ │   │  │ 49 20 61 6c 73 6f 20 68 61 70 70 65 6e 20 74 6f │ I also happen to │
+ │   │  │ 20 62 65 20 72 65 74 61 69 6e 65 64 20 62 65 63 │  be retained bec │
+ │   │  │ 61 75 73 65 20 49 20 68 61 76 65 20 74 68 65 20 │ ause I have the  │
+ │   │  │ 73 61 6d 65 20 6e 61 6d 65 00 49 20 72 65 61 6c │ same name.I real │
+ │   │  │ 6c 79 20 77 61 6e 74 20 74 6f 20 62 65 20 72 65 │ ly want to be re │
+ │   │  │ 74 61 69 6e 65 64 00                            │ tained.          │
+ │   │  ╰─────────────────────────────────────────────────┴──────────────────╯
  │   ┴
  │
  │  section names section .shstrtab in <plinky>

--- a/plinky/src/linker.rs
+++ b/plinky/src/linker.rs
@@ -15,8 +15,8 @@ use crate::repr::object::Object;
 use crate::repr::sections::SectionId;
 use crate::utils::address_resolver::AddressResolver;
 use plinky_diagnostics::GatheredContext;
-use plinky_elf::writer::layout::{Layout, LayoutError};
 use plinky_elf::ElfObject;
+use plinky_elf::writer::layout::{Layout, LayoutError};
 use plinky_macros::{Display, Error};
 
 pub(crate) struct Linker {
@@ -56,12 +56,12 @@ impl Linker {
 
         passes::mark_shared_library_symbols::run(&mut object);
 
+        passes::merge_sections::run(&mut object)?;
+
         if options.gc_sections {
             let removed = passes::gc_sections::run(&mut object);
             callbacks.on_sections_removed_by_gc(&object, &removed);
         }
-
-        passes::merge_sections::run(&mut object)?;
 
         let relocs_analysis = passes::analyze_relocations::run(&object)?;
         callbacks.on_relocations_analyzed(&object, &relocs_analysis);

--- a/plinky/src/passes/build_elf/mod.rs
+++ b/plinky/src/passes/build_elf/mod.rs
@@ -174,6 +174,7 @@ impl<'a> ElfBuilder<'a> {
                 memory_address: 0,
                 part_of_group: false,
                 content: ElfSectionContent::Null,
+                retain: false,
             },
         );
 
@@ -258,6 +259,7 @@ impl<'a> ElfBuilder<'a> {
                         .map(|m| m.address.extract())
                         .unwrap_or(0),
                     part_of_group: false,
+                    retain: section.retain,
                     content,
                 },
             );

--- a/plinky/src/passes/gc_sections.rs
+++ b/plinky/src/passes/gc_sections.rs
@@ -40,7 +40,7 @@ pub(crate) fn run(object: &mut Object) -> Vec<RemovedSection> {
             SectionContent::Data(data) if data.perms.read => {}
             SectionContent::Uninitialized(uninit) if uninit.perms.read => {}
             _ => {
-                visitor.to_save.insert(section.id);
+                visitor.queue.insert(section.id);
             }
         }
 

--- a/plinky/src/passes/gc_sections.rs
+++ b/plinky/src/passes/gc_sections.rs
@@ -33,15 +33,20 @@ pub(crate) fn run(object: &mut Object) -> Vec<RemovedSection> {
         visitor.add(symbol.id());
     }
 
-    // Mark all sections that will not be allocated in memory to be saved, as checking the
-    // relocations from the entry point is not accurate for that.
     for section in object.sections.iter() {
+        // Mark all sections that will not be allocated in memory to be saved, as checking the
+        // relocations from the entry point is not accurate for that.
         match &section.content {
             SectionContent::Data(data) if data.perms.read => {}
             SectionContent::Uninitialized(uninit) if uninit.perms.read => {}
             _ => {
                 visitor.to_save.insert(section.id);
             }
+        }
+
+        // Mark all retained (`#[used(linker)`, `__attribute__((retain))`) section as saved.
+        if section.retain {
+            visitor.queue.insert(section.id);
         }
     }
 

--- a/plinky/src/passes/load_inputs/merge_elf.rs
+++ b/plinky/src/passes/load_inputs/merge_elf.rs
@@ -39,11 +39,11 @@ pub(super) fn merge_elf(
             ElfSectionContent::Null => {}
             ElfSectionContent::Program(program) => {
                 section_placeholders.insert(section_id, object.sections.reserve_placeholder());
-                program_sections.push((section_id, section.name, program))
+                program_sections.push((section_id, section.name, section.retain, program))
             }
             ElfSectionContent::Uninitialized(uninit) => {
                 section_placeholders.insert(section_id, object.sections.reserve_placeholder());
-                uninitialized_sections.push((section_id, section.name, uninit));
+                uninitialized_sections.push((section_id, section.name, section.retain, uninit));
             }
             ElfSectionContent::SymbolTable(table) => {
                 if table.dynsym {
@@ -142,7 +142,7 @@ pub(super) fn merge_elf(
         )?;
     }
 
-    for (id, name, uninit) in uninitialized_sections {
+    for (id, name, retain, uninit) in uninitialized_sections {
         if section_groups.should_skip_section(id) {
             continue;
         }
@@ -155,10 +155,11 @@ pub(super) fn merge_elf(
                 UninitializedSection { perms: uninit.perms, len: uninit.len.into() },
             )
             .source(source.clone())
+            .retain(retain)
             .create_in_placeholder(placeholder);
     }
 
-    for (id, name, program) in program_sections {
+    for (id, name, retain, program) in program_sections {
         if section_groups.should_skip_section(id) {
             continue;
         }
@@ -188,6 +189,7 @@ pub(super) fn merge_elf(
                 },
             )
             .source(source.clone())
+            .retain(retain)
             .create_in_placeholder(placeholder);
     }
 

--- a/plinky/src/repr/sections.rs
+++ b/plinky/src/repr/sections.rs
@@ -47,6 +47,7 @@ impl Sections {
             name: intern(name),
             content: content.into(),
             source: ObjectSpan::new_synthetic(),
+            retain: false,
         }
     }
 
@@ -131,11 +132,17 @@ pub(crate) struct SectionBuilder<'a> {
     name: Interned<String>,
     content: SectionContent,
     source: ObjectSpan,
+    retain: bool,
 }
 
 impl SectionBuilder<'_> {
     pub(crate) fn source(mut self, source: ObjectSpan) -> Self {
         self.source = source;
+        self
+    }
+
+    pub(crate) fn retain(mut self, retain: bool) -> Self {
+        self.retain = retain;
         self
     }
 
@@ -146,6 +153,7 @@ impl SectionBuilder<'_> {
             name: self.name,
             source: self.source,
             content: self.content,
+            retain: self.retain,
             _prevent_creation: (),
         }));
         id
@@ -163,6 +171,7 @@ impl SectionBuilder<'_> {
                     name: self.name,
                     source: self.source,
                     content: self.content,
+                    retain: self.retain,
                     _prevent_creation: (),
                 });
                 placeholder
@@ -188,6 +197,7 @@ pub(crate) struct Section {
     pub(crate) name: Interned<String>,
     pub(crate) source: ObjectSpan,
     pub(crate) content: SectionContent,
+    pub (crate) retain: bool,
     _prevent_creation: (),
 }
 

--- a/plinky_elf/src/raw.rs
+++ b/plinky_elf/src/raw.rs
@@ -70,6 +70,9 @@ pub struct RawSectionHeaderFlags {
     pub info_link: bool,
     #[bit(9)]
     pub group: bool,
+    /// `SHF_GNU_RETAIN`
+    #[bit(21)]
+    pub gnu_retain: bool,
 }
 
 #[derive(RawType)]

--- a/plinky_elf/src/reader/header.rs
+++ b/plinky_elf/src/reader/header.rs
@@ -27,6 +27,7 @@ pub(crate) fn read_header(cursor: &mut ReadCursor<'_>) -> Result<ReadHeader, Loa
     };
     let abi = match (identification.abi, identification.abi_version) {
         (0, 0) => ElfABI::SystemV,
+        (3, 0) => ElfABI::Gnu,
         (0, version) => return Err(LoadError::BadAbiVersion(ElfABI::SystemV, version)),
         (abi, _) => return Err(LoadError::BadAbi(abi)),
     };

--- a/plinky_elf/src/reader/sections/mod.rs
+++ b/plinky_elf/src/reader/sections/mod.rs
@@ -124,11 +124,15 @@ fn read_section_inner(
         }
     };
 
+    // TODO: limit it only to ELFOSABI_GNU
+    let is_retain = header.flags.gnu_retain;
+
     Ok(ElfSection {
         name: ElfStringId { section: section_names_table, offset: header.name_offset },
         memory_address: header.memory_address,
         part_of_group: header.flags.group,
         content,
+        retain: is_retain,
     })
 }
 

--- a/plinky_elf/src/render_elf/meta.rs
+++ b/plinky_elf/src/render_elf/meta.rs
@@ -21,6 +21,7 @@ pub(super) fn render_meta(object: &ElfObject) -> impl Widget + use<> {
         "ABI",
         match object.env.abi {
             ElfABI::SystemV => "System V",
+            ElfABI::Gnu => "GNU",
         },
     ]);
     table.add_body([

--- a/plinky_elf/src/types/mod.rs
+++ b/plinky_elf/src/types/mod.rs
@@ -45,6 +45,7 @@ impl From<ElfClass> for Bits {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ElfABI {
     SystemV,
+    Gnu,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,6 +81,7 @@ pub struct ElfSection {
     pub memory_address: u64,
     pub part_of_group: bool,
     pub content: ElfSectionContent,
+    pub retain: bool,
 }
 
 #[derive(Debug)]

--- a/plinky_elf/src/writer/mod.rs
+++ b/plinky_elf/src/writer/mod.rs
@@ -103,9 +103,11 @@ impl<'a> Writer<'a> {
             version: 1,
             abi: match self.object.env.abi {
                 ElfABI::SystemV => 0,
+                ElfABI::Gnu => 3,
             },
             abi_version: match self.object.env.abi {
                 ElfABI::SystemV => 0,
+                ElfABI::Gnu => 0,
             },
             padding: RawPadding,
         })


### PR DESCRIPTION
This section flag (`R`) is used for `#[used(linker)]` in Rust and `__attribute__((retain))` in GCC. It marks a section as being a GC root to avoid removing it with `--gc-sections`.

This parses the flag, forwards it through the linker, and then uses it in the GC pass. To make it work properly, it also accepting the GNU ABI, since SHF_GNU_RETAIN is a GNU extension

To make it match BFD as closely as possible, I moved section merging before gc-sections. With the following assembly:
```asm
.section .rodata.retained_same_name,"a",%progbits
    .asciz "I also happen to be retained because I have the same name"

.section .rodata.retained_same_name,"aR",%progbits
    .asciz "I really want to be retained"
```

BFD would produce a single section that contained *both* contents (LLD too), being evidence that the section were merged first (preserving `R` on the result) and then being gced. This move didn't lead to any other test failures.